### PR TITLE
Patch 1

### DIFF
--- a/final_parsing.rb
+++ b/final_parsing.rb
@@ -1,20 +1,20 @@
 require 'optimist'
 
 opts = Optimist::options do
-  opt :blastfile, "File with blast information.", :type => :string, :short => "-b"
+  opt :usearchfile, "File with usearch local information.", :type => :string, :short => "-b"
   opt :otuutaxfile, "File with OTU table and utax information.", :type => :string, :short => "-u", required: true
   opt :ncbiclusteredfile, "File with info about DB clustered", :type => :string, :short => "-n"
   opt :outfile, "Output file with OTU names, OTU counts, lineage and blast results.", :type => :string, :short => "-o", required: true
 end
 
-blast_file = File.open(opts[:blastfile], "r") unless opts[:blastfile].nil?
+usearch_file = File.open(opts[:usearchfile], "r") unless opts[:usearchfile].nil?
 otu_utax_file = File.open(opts[:otuutaxfile], "r")
 ncbi_clustered_file = File.open(opts[:ncbiclusteredfile], "r") unless opts[:ncbiclusteredfile].nil?
 out_file = File.open(opts[:outfile], "w")
 
-blast_file_hash = {}
-if !blast_file.nil?
-	blast_file.each do |line|
+usearch_file_hash = {}
+if !usearch_file.nil?
+	usearch_file.each do |line|
 		line_split = line.split("\t")
 		#puts line_split[0]
 		# get the otu name which will be the key of the hash
@@ -38,9 +38,9 @@ if !blast_file.nil?
 		alignment_length = line_split[3]
 
 		# populate the hash 
-		blast_file_hash[key] = [query, strain, complete, percent_identity, alignment_length]
+		usearch_file_hash[key] = [query, strain, complete, percent_identity, alignment_length]
 	end
-	#puts blast_file_hash
+	#puts usearch_file_hash
 end
 
 ncbi_clustered_hash = {}
@@ -69,7 +69,7 @@ end
 
 header = File.open(otu_utax_file, &:readline)
 header_split = header.split("\t")[0..-2].join("\t")
-out_file.puts(header_split+"\tdomain\tdomain_conf\tphylum\tphylum_conf\tclass\tclass_conf\torder\torder_conf\tfamily\tfamily_conf\tgenus\tgenus_conf\tspecies\tspecies_conf\tblast_query\tblast_strain\tblast_16s_completeness\tblast_percent_identity\tblast_alignment_length\tncbi_avglinkage_otu_id\tnum_of_sp_in_cluster\tnum_of_sp_in_db\tnum_of_otus_with_same_sp")
+out_file.puts(header_split+"\tdomain\tdomain_conf\tphylum\tphylum_conf\tclass\tclass_conf\torder\torder_conf\tfamily\tfamily_conf\tgenus\tgenus_conf\tspecies\tspecies_conf\tusearch_query\tusearch_strain\tusearch_16s_completeness\tusearch_percent_identity\tusearch_alignment_length\tncbi_avglinkage_otu_id\tnum_of_sp_in_cluster\tnum_of_sp_in_db\tnum_of_otus_with_same_sp")
 
 otu_utax_file.each_with_index do |line, index|
 	if index == 0
@@ -81,11 +81,11 @@ otu_utax_file.each_with_index do |line, index|
     capture_array = /d:([^(]+)\(([^)]+)\),p:([^(]+)\(([^)]+)\),c:([^(]+)\(([^)]+)\),o:([^(]+)\(([^)]+)\),f:([^(]+)\(([^)]+)\),g:([^(]+)\(([^)]+)\),s:([^(]+)\(([^)]+)\)/.match(line)
     #puts capture_array
     puts capture_array[1]+"\t"+capture_array[2]+"\t"+capture_array[3]+"\t"+capture_array[4]+"\t"+capture_array[5]+"\t"+capture_array[6]+"\t"+capture_array[7]+"\t"+capture_array[8]+"\t"+capture_array[9]+"\t"+capture_array[10]+"\t"+capture_array[11]+"\t"+capture_array[12]+"\t"+capture_array[13]
-    #next unless blast_file_hash.has_key?(key)
-    if ncbi_clustered_hash.has_key?(capture_array[13]) and blast_file_hash.has_key?(key)
-     	out_file.puts(line_split[0..-2].join("\t")+"\t"+capture_array[1..-1].join("\t")+"\t"+blast_file_hash[key][0..-1].join("\t")+"\t"+ncbi_clustered_hash[capture_array[13]].join("\t"))
-		elsif blast_file_hash.has_key?(key)
-			out_file.puts(line_split[0..-2].join("\t")+"\t"+capture_array[1..-1].join("\t")+"\t"+blast_file_hash[key][0..-1].join("\t")+"\tNA\tNA\tNA\tNA")
+    #next unless usearch_file_hash.has_key?(key)
+    if ncbi_clustered_hash.has_key?(capture_array[13]) and usearch_file_hash.has_key?(key)
+     	out_file.puts(line_split[0..-2].join("\t")+"\t"+capture_array[1..-1].join("\t")+"\t"+usearch_file_hash[key][0..-1].join("\t")+"\t"+ncbi_clustered_hash[capture_array[13]].join("\t"))
+		elsif usearch_file_hash.has_key?(key)
+			out_file.puts(line_split[0..-2].join("\t")+"\t"+capture_array[1..-1].join("\t")+"\t"+usearch_file_hash[key][0..-1].join("\t")+"\tNA\tNA\tNA\tNA")
 		elsif ncbi_clustered_hash.has_key?(capture_array[13]) 
 			out_file.puts(line_split[0..-2].join("\t")+"\t"+capture_array[1..-1].join("\t")+"\tNA\tNA\tNA\tNA\tNA\t"+ncbi_clustered_hash[capture_array[13]].join("\t"))
 		else

--- a/mcsmrt.rb
+++ b/mcsmrt.rb
@@ -637,10 +637,10 @@ puts "Generating Reports...".green.bold
 `ruby #{script_directory}/get_report.rb #{final_fastq_basename}`
 puts "Done.".green.bold
 
-# Running blast on the OTUs
+# Running USEARCH on the OTUs
 if !opts[:utaxdbfile].nil?
-  puts "Blasting OTU centroids...".magenta.bold                                                                                  
-  `usearch -ublast post_OTU.fa -db #{utax_db_file} -top_hit_only -id 0.9 -blast6out post_OTU_blast.txt -strand both -evalue 0.01 -threads #{thread} -accel 0.3`
+  puts "Identifying high-identity alignments of OTU centroids to reference sequences...".magenta.bold                                                                                  
+  `usearch -usearch_local post_OTU.fa -db #{utax_db_file} -top_hit_only -id 0.9 -blast6out post_OTU_blast.txt -strand both -evalue 0.01 -threads #{thread}`
   puts "Done.".magenta.bold
 
   # Running the script whcih gives a final file with all the clustering info, taxa info and blast info

--- a/mcsmrt.rb
+++ b/mcsmrt.rb
@@ -637,7 +637,7 @@ puts "Generating Reports...".green.bold
 `ruby #{script_directory}/get_report.rb #{final_fastq_basename}`
 puts "Done.".green.bold
 
-# Running USEARCH on the OTUs
+# Running usearch on the OTUs
 if !opts[:utaxdbfile].nil?
   puts "Identifying high-identity alignments of OTU centroids to reference sequences...".magenta.bold                                                                                  
   `usearch -usearch_local post_OTU.fa -db #{utax_db_file} -top_hit_only -id 0.9 -blast6out post_OTU_usearch_local.txt -strand both -evalue 0.01 -threads #{thread}`

--- a/mcsmrt.rb
+++ b/mcsmrt.rb
@@ -714,7 +714,7 @@ if verbose == true
 else
   File.delete("post_dereplicated.fa")
   File.delete("post_OTU_alignment.aln")
-  File.delete("post_OTU_blast.txt")
+  File.delete("post_OTU_usearch_local.txt")
   File.delete("post_OTU_chimeras.fa")
   File.delete("post_OTU_nonchimeras.fa")
   File.delete("post_OTU_table.tsv")

--- a/mcsmrt.rb
+++ b/mcsmrt.rb
@@ -640,7 +640,7 @@ puts "Done.".green.bold
 # Running USEARCH on the OTUs
 if !opts[:utaxdbfile].nil?
   puts "Identifying high-identity alignments of OTU centroids to reference sequences...".magenta.bold                                                                                  
-  `usearch -usearch_local post_OTU.fa -db #{utax_db_file} -top_hit_only -id 0.9 -blast6out post_OTU_blast.txt -strand both -evalue 0.01 -threads #{thread}`
+  `usearch -usearch_local post_OTU.fa -db #{utax_db_file} -top_hit_only -id 0.9 -blast6out post_OTU_usearch_local.txt -strand both -evalue 0.01 -threads #{thread}`
   puts "Done.".magenta.bold
 
   # Running the script whcih gives a final file with all the clustering info, taxa info and blast info


### PR DESCRIPTION
Changed and tested the algorithm used to find high-identity matches of OTU centroids to reference sequence database. The usearch local algorithm more accurately identifies matches to reference database compared to ublast algorithm (original algorithm used by MCSMRT). Usearch local finds twice as many hits compared to ublast, and the results correspond more closely with the taxonomic predictions made in MCSMRT. As a note, Edgar makes a note that ublast is typically used for protein sequences, however, he also says that usearch local is typically not used in practice. This is confusing for users, but for the purposes herein, ublast provides contradictory, low-identity results, or no hit at all, so I made changes to the post_final_results.tsv file column headers in final_parsing.rb to reflect the change, as well as made changes to the code and comments to make the change clear. I have tested on two different datasets, both completing successfully without error.